### PR TITLE
Updated Example/Podfile to explicitly specify Artsy+UILabels.podspec

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,12 +3,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target 'LabelsApp' do
   pod 'Artsy+OSSUIFonts'
-  pod "Artsy+UILabels", :path => "../"
+  pod "Artsy+UILabels", :path => "../Artsy+UILabels.podspec"
 end
 
 target 'Tests', :exclusive => true do
   pod 'Artsy+OSSUIFonts'
-  pod "Artsy+UILabels", :path => "../"
+  pod "Artsy+UILabels", :path => "../Artsy+UILabels.podspec"
 
   pod 'Specta'
   pod 'Expecta'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Artsy+OSSUIFonts (1.0.0)
   - Artsy+UIColors (1.0.0):
     - EDColor (~> 0.4)
-  - Artsy+UILabels (1.2.0):
+  - Artsy+UILabels (1.3.1):
     - Artsy+UIColors
   - EDColor (0.4.0)
   - Expecta (0.3.1)
@@ -14,7 +14,7 @@ PODS:
 
 DEPENDENCIES:
   - Artsy+OSSUIFonts
-  - Artsy+UILabels (from `../`)
+  - Artsy+UILabels (from `../Artsy+UILabels.podspec`)
   - Expecta
   - EXPMatchers+FBSnapshotTest
   - FBSnapshotTestCase
@@ -22,16 +22,16 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Artsy+UILabels:
-    :path: ../
+    :path: ../Artsy+UILabels.podspec
 
 SPEC CHECKSUMS:
   Artsy+OSSUIFonts: 45b406bdb7b79dc23ec8e7eeab58a868a147c067
   Artsy+UIColors: d1d5e084a0e542d310c507acb5446bae6a322241
-  Artsy+UILabels: f327cdd339e99fb1a1ff26b9e5caf89545917b8c
+  Artsy+UILabels: 9226e7db849dbba31ba5d33c56303f72f8a1294c
   EDColor: bcdb8600b7a456f4408ce1d7e7fc001588919254
   Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
   EXPMatchers+FBSnapshotTest: 3c48e8a29a445476fe2d72d7da45dfdd765b5f55
   FBSnapshotTestCase: 4159bdf235fdae25aa7d813f1452a4f05ad4f9cd
   Specta: 9141310f46b1f68b676650ff2854e1ed0b74163a
 
-COCOAPODS: 0.34.1
+COCOAPODS: 0.34.4


### PR DESCRIPTION
@orta 

I was having difficulty getting this setup on my machine.
I'm not sure if it's something I was doing wrong or if my environment doesn't match yours.

I was getting this output when I tried running `pod install` from Example folder.
![screen shot 2014-11-06 at 23 09 48](https://cloud.githubusercontent.com/assets/1572886/4945723/ad59606a-660a-11e4-9182-1fbeff7d76e2.png)

Managed to get around it by explicitly specifying `Artsy+UILabels.podspec` in the Podfile
